### PR TITLE
Week4 review tests and makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -7,6 +7,8 @@ env:
 update: env
 	. env/bin/activate; pip install -r requirements.txt
 
+test:
+	. env/bin/activate; pytest -vvx tests
 
 get_texts: book_Raven.txt book_FallHouseUsher.txt book_CaskAmontillado.txt book_Poems.txt book_LeCorbeau.txt
 # 1064-0.txt 51060-8.txt 50852-0.txt 32037.txt 2147-0.txt 2148-0.txt 2149-0.txt

--- a/tests/test_1_clean_text.py
+++ b/tests/test_1_clean_text.py
@@ -1,7 +1,7 @@
 import os
 import logging, sys
 
-relative_path = os.path.abspath('./../')
+relative_path = os.path.abspath('.')
 sys.path.append(relative_path)
 
 from data_prep import *

--- a/tests/test_1_count_words.py
+++ b/tests/test_1_count_words.py
@@ -1,7 +1,7 @@
 import os
 import logging, sys
 
-relative_path = os.path.abspath('./../')
+relative_path = os.path.abspath('.')
 sys.path.append(relative_path)
 
 from data_prep import *

--- a/tests/test_1_tokenize_text.py
+++ b/tests/test_1_tokenize_text.py
@@ -1,7 +1,7 @@
 import os
 import logging, sys
 
-relative_path = os.path.abspath('./../')
+relative_path = os.path.abspath('.')
 sys.path.append(relative_path)
 
 from data_prep import *

--- a/tests/test_2_clean_text.py
+++ b/tests/test_2_clean_text.py
@@ -3,7 +3,7 @@ import logging, sys
 
 from decorator import decorator
 
-relative_path = os.path.abspath('./../')
+relative_path = os.path.abspath('.')
 sys.path.append(relative_path)
 
 from data_prep import *

--- a/tests/test_2_count_words.py
+++ b/tests/test_2_count_words.py
@@ -3,7 +3,7 @@ import logging, sys
 
 from decorator import decorator
 
-relative_path = os.path.abspath('./../')
+relative_path = os.path.abspath('.')
 sys.path.append(relative_path)
 
 from data_prep import *

--- a/tests/test_2_tokenize_text.py
+++ b/tests/test_2_tokenize_text.py
@@ -3,7 +3,7 @@ import logging, sys
 
 from decorator import decorator
 
-relative_path = os.path.abspath('./../')
+relative_path = os.path.abspath('.')
 sys.path.append(relative_path)
 
 from data_prep import *

--- a/tests/test_3_clean_text.py
+++ b/tests/test_3_clean_text.py
@@ -1,7 +1,7 @@
 import os
 import logging, sys
 
-relative_path = os.path.abspath('./../')
+relative_path = os.path.abspath('.')
 sys.path.append(relative_path)
 
 from data_prep import *
@@ -12,7 +12,7 @@ logging.basicConfig(level = logging.INFO, stream = sys.stderr,
 
 log = logging.getLogger(__name__)
 
-with open('./../pg17192.txt', 'r') as file:
+with open('./pg17192.txt', 'r') as file:
     the_raven = file.read()
 
 

--- a/tests/test_3_count_words.py
+++ b/tests/test_3_count_words.py
@@ -1,7 +1,7 @@
 import os
 import logging, sys
 
-relative_path = os.path.abspath('./../')
+relative_path = os.path.abspath('.')
 sys.path.append(relative_path)
 
 from data_prep import *
@@ -12,7 +12,7 @@ logging.basicConfig(level = logging.INFO, stream = sys.stderr,
 
 log = logging.getLogger(__name__)
 
-with open('./../pg17192.txt', 'r') as file:
+with open('./pg17192.txt', 'r') as file:
     the_raven = file.read()
 
 

--- a/tests/test_3_tokenize_text.py
+++ b/tests/test_3_tokenize_text.py
@@ -1,7 +1,7 @@
 import os
 import logging, sys
 
-relative_path = os.path.abspath('./../')
+relative_path = os.path.abspath('.')
 sys.path.append(relative_path)
 
 from data_prep import *
@@ -12,7 +12,7 @@ logging.basicConfig(level = logging.INFO, stream = sys.stderr,
 
 log = logging.getLogger(__name__)
 
-with open('./../pg17192.txt', 'r') as file:
+with open('./pg17192.txt', 'r') as file:
     the_raven = file.read()
 
 

--- a/tests/test_4_clean_text.py
+++ b/tests/test_4_clean_text.py
@@ -1,7 +1,7 @@
 import os, logging, sys
 import pytest
 
-relative_path = os.path.abspath('./../')
+relative_path = os.path.abspath('.')
 sys.path.append(relative_path)
 
 from data_prep import *
@@ -15,10 +15,10 @@ log = logging.getLogger(__name__)
 @pytest.mark.parametrize(
     "book_name, file_name",
     [
-        ("The Raven", "./../pg17192.txt"),
-        ("The Fall of the House of Usher", "./../932.txt"),
-        ("The Cask of Amontillado", "./../1063.txt"),
-        ("The Poems", "./../10031-0.txt"),
+        ("The Raven", "./pg17192.txt"),
+        ("The Fall of the House of Usher", "./932.txt"),
+        ("The Cask of Amontillado", "./1063.txt"),
+        ("The Poems", "./10031-0.txt"),
         # ("Le Corbeau", "./../pg14082.txt")
     ]
 )

--- a/tests/test_4_count_words.py
+++ b/tests/test_4_count_words.py
@@ -1,7 +1,7 @@
 import os, logging, sys
 import pytest
 
-relative_path = os.path.abspath('./../')
+relative_path = os.path.abspath('.')
 sys.path.append(relative_path)
 
 from data_prep import *
@@ -15,10 +15,10 @@ log = logging.getLogger(__name__)
 @pytest.mark.parametrize(
     "book_name, file_name",
     [
-        ("The Raven", "./../pg17192.txt"),
-        ("The Fall of the House of Usher", "./../932.txt"),
-        ("The Cask of Amontillado", "./../1063.txt"),
-        ("The Poems", "./../10031-0.txt"),
+        ("The Raven", "./pg17192.txt"),
+        ("The Fall of the House of Usher", "./932.txt"),
+        ("The Cask of Amontillado", "./1063.txt"),
+        ("The Poems", "./10031-0.txt"),
         # ("Le Corbeau", "./../pg14082.txt")
     ]
 )

--- a/tests/test_4_tokenize_text.py
+++ b/tests/test_4_tokenize_text.py
@@ -1,7 +1,7 @@
 import os, logging, sys
 import pytest
 
-relative_path = os.path.abspath('./../')
+relative_path = os.path.abspath('.')
 sys.path.append(relative_path)
 
 from data_prep import *
@@ -15,11 +15,11 @@ log = logging.getLogger(__name__)
 @pytest.mark.parametrize(
     "book_name, file_name",
     [
-        ("The Raven", "./../pg17192.txt"),
-        ("The Fall of the House of Usher", "./../932.txt"),
-        ("The Cask of Amontillado", "./../1063.txt"),
-        ("The Poems", "./../10031-0.txt"),
-        # ("Le Corbeau", "./../pg14082.txt")
+        ("The Raven", "./pg17192.txt"),
+        ("The Fall of the House of Usher", "./932.txt"),
+        ("The Cask of Amontillado", "./1063.txt"),
+        ("The Poems", "./10031-0.txt"),
+        # ("Le Corbeau", ".pg14082.txt")
     ]
 )
 def test_tokenize_text(book_name, file_name):

--- a/tests/test_5_clean_text.py
+++ b/tests/test_5_clean_text.py
@@ -1,6 +1,6 @@
 import os, logging, sys
 
-relative_path = os.path.abspath('./../')
+relative_path = os.path.abspath('.')
 sys.path.append(relative_path)
 
 from data_prep import *
@@ -23,11 +23,11 @@ def test_clean_text():
     combined_text = ""
 
     books = [
-        "./../pg17192.txt",
-        "./../932.txt",
-        "./../1063.txt",
-        "./../10031-0.txt",
-        # "./../pg14082.txt"
+        "./pg17192.txt",
+        "./932.txt",
+        "./1063.txt",
+        "./10031-0.txt",
+        # "./pg14082.txt"
         ]
 
     for book in books:

--- a/tests/test_5_count_words.py
+++ b/tests/test_5_count_words.py
@@ -1,6 +1,6 @@
 import os, logging, sys
 
-relative_path = os.path.abspath('./../')
+relative_path = os.path.abspath('.')
 sys.path.append(relative_path)
 
 from data_prep import *
@@ -24,11 +24,11 @@ def test_count_words():
     combined_text = ""
 
     books = [
-        "./../pg17192.txt",
-        "./../932.txt",
-        "./../1063.txt",
-        "./../10031-0.txt",
-        # "./../pg14082.txt"
+        "./pg17192.txt",
+        "./932.txt",
+        "./1063.txt",
+        "./10031-0.txt",
+        # "./pg14082.txt"
         ]
 
     for book in books:

--- a/tests/test_5_tokenize_text.py
+++ b/tests/test_5_tokenize_text.py
@@ -1,6 +1,6 @@
 import os, logging, sys
 
-relative_path = os.path.abspath('./../')
+relative_path = os.path.abspath('.')
 sys.path.append(relative_path)
 
 from data_prep import *
@@ -24,11 +24,11 @@ def test_tokenize_text():
     combined_text = ""
 
     books = [
-        "./../pg17192.txt",
-        "./../932.txt",
-        "./../1063.txt",
-        "./../10031-0.txt",
-        # "./../pg14082.txt"
+        "./pg17192.txt",
+        "./932.txt",
+        "./1063.txt",
+        "./10031-0.txt",
+        # "./pg14082.txt"
         ]
 
     for book in books:

--- a/tests/test_6_clean_text.py
+++ b/tests/test_6_clean_text.py
@@ -1,6 +1,6 @@
 import os, logging, sys
 
-relative_path = os.path.abspath('./../')
+relative_path = os.path.abspath('.')
 sys.path.append(relative_path)
 
 from data_prep import *

--- a/tests/test_6_count_words.py
+++ b/tests/test_6_count_words.py
@@ -1,6 +1,6 @@
 import os, logging, sys
 
-relative_path = os.path.abspath('./../')
+relative_path = os.path.abspath('.')
 sys.path.append(relative_path)
 
 from data_prep import *

--- a/tests/test_6_tokenize_text.py
+++ b/tests/test_6_tokenize_text.py
@@ -1,6 +1,6 @@
 import os, logging, sys
 
-relative_path = os.path.abspath('./../')
+relative_path = os.path.abspath('.')
 sys.path.append(relative_path)
 
 from data_prep import *

--- a/tests/test_bash.py
+++ b/tests/test_bash.py
@@ -1,7 +1,7 @@
 import os, logging, sys
 import subprocess
 
-relative_path = os.path.abspath('./../')
+relative_path = os.path.abspath('.')
 sys.path.append(relative_path)
 
 from data_prep import *
@@ -12,7 +12,7 @@ logging.basicConfig(level = logging.INFO, stream = sys.stderr,
 
 log = logging.getLogger(__name__)
 
-with open('./../pg17192.txt', 'r') as file:
+with open('./pg17192.txt', 'r') as file:
     text = file.read()
 
 # keyword = 'raven'
@@ -35,7 +35,7 @@ def test_bash_vs_python_functions():
     Then I should get 46 instances of the word 'raven' for both methods.
     """
 
-    filename = './../pg17192.txt'
+    filename = './pg17192.txt'
 
     bash_command = f"cat {filename} | grep -i raven | wc -l"
     bash_output = run_bash_command(bash_command)

--- a/tests/test_skip.py
+++ b/tests/test_skip.py
@@ -3,7 +3,7 @@ import os, logging, sys
 import platform
 from packaging.version import parse
 
-relative_path = os.path.abspath('./../')
+relative_path = os.path.abspath('.')
 sys.path.append(relative_path)
 
 from data_prep import *


### PR DESCRIPTION
1.  Added test job to makefile
2. Shifted all tests to work from the root of the repository.  That is where make is executed, and where python/pytest will be invoked, so it becomes the 'from' relative location.  This is the '.' in the `relative_path = os.path.abspath('.')`
3. Shifted all the paths to the files to also point to the root of the repo, for the same reason as above.  Since execution begins there, files at that location can be referenced directly, or equivalently by the `./` appended.

Tests ran to completion with all passing, NICE!